### PR TITLE
Move WiFi to event based

### DIFF
--- a/.changeset/itchy-brooms-turn.md
+++ b/.changeset/itchy-brooms-turn.md
@@ -1,0 +1,5 @@
+---
+"firmware-pio": patch
+---
+
+Move WiFi to event based to avoid blocking processing of the shell commands

--- a/firmware-pio/src/internet/korra_wifi.h
+++ b/firmware-pio/src/internet/korra_wifi.h
@@ -63,9 +63,8 @@ public:
    * Save the credentials to the preferences.
    *
    * @param credentials The credentials.
-   * @param disconnect Whether to disconnect the network.
    */
-  bool credentials_save(const struct wifi_credentials *credentials, bool disconnect = false);
+  bool credentials_save(const struct wifi_credentials *credentials);
 
   /**
    * Clear the credentials from the preferences.
@@ -82,9 +81,23 @@ public:
    */
   inline bool connected() { return WiFi.isConnected(); }
 
+  /**
+   * Returns existing instance (singleton) of the KorraWiFi class.
+   * It may be a null pointer if the KorraWiFi object was never constructed or it was destroyed.
+   */
+  inline static KorraWiFi *instance() { return _instance; }
+
+  /**
+   * Please do not call this method from outside the `KorraWiFi` class
+   */
+  void on_wifi_event(WiFiEvent_t event, WiFiEventInfo_t info);
+
+  /// Living instance of the KorraWiFi class. It can be nullptr.
+  static KorraWiFi *_instance;
+
 private:
   Preferences &prefs;
-  uint8_t _status;
+  bool connection_requested = 0;
   struct wifi_credentials credentials = {0};
   struct korra_network_props net_props = {0};
   bool logged_missing_creds;
@@ -94,8 +107,9 @@ private:
   void listNetworks();
 #endif // CONFIG_WIFI_SCAN_NETWORKS
 
-  void connect(bool initial);
+  void connect();
   void credentials_load();
+  void credentials_print();
 };
 
 #endif // BOARD_HAS_WIFI

--- a/firmware-pio/src/korra_config.h
+++ b/firmware-pio/src/korra_config.h
@@ -5,11 +5,6 @@
 #define CONFIG_BOARD_HAS_WIFI 1
 #endif
 
-#ifdef CONFIG_BOARD_HAS_WIFI
-// The amount of time to wait for a WiFi connection before rebooting
-#define CONFIG_WIFI_CONNECTION_REBOOT_TIMEOUT_SEC 30
-#endif // CONFIG_BOARD_HAS_WIFI
-
 // General Network
 #ifdef CONFIG_BOARD_HAS_WIFI // || CONFIG_BOARD_HAS_ETHERNET || CONFIG_BOARD_HAS_CELLULAR
 #define CONFIG_BOARD_HAS_INTERNET 1

--- a/firmware-pio/src/mdns/korra_mdns.cpp
+++ b/firmware-pio/src/mdns/korra_mdns.cpp
@@ -8,35 +8,38 @@ KorraMdns::KorraMdns(UDP &client) : mdns(client) {}
 
 KorraMdns::~KorraMdns() {}
 
-void KorraMdns::begin(const struct korra_network_props *props)
+void KorraMdns::maintain(const struct korra_network_props *props)
 {
-  if (!mdns.begin(props->local_ipaddr, props->hostname))
+  if (!setup)
   {
-    Serial.println("Error setting up mDNS! Rebooting in 5 sec ....");
-    delay(5000);
-    sys_reboot();
+    if (!mdns.begin(props->local_ipaddr, props->hostname))
+    {
+      Serial.println("Error setting up mDNS! Rebooting in 5 sec ....");
+      delay(5000);
+      sys_reboot();
+    }
+
+    // We register a service to aid with checking if the device is on the network. This aids troubleshooting
+    // service discovery where network has different conditions like mDNS/Bonjour disabled, different VLAN.
+    // The name must start with the description as per examples.
+    // Without the TXT record, sometimes execution crashes; see https://github.com/arduino-libraries/ArduinoMDNS/issues/36
+    //                                                          https://github.com/arduino-libraries/ArduinoMDNS/pull/23
+    // The TXT record "\x05id=01" implies TXT record with 5 bytes 'id=01' which is just a random key value pair
+    // Post 7007 is random, not using 80 to avoid confusion with HTTP.
+    // The service name includes the mac address to make it easier to identify multiple devices.
+    // You can list this on Linux using "avahi-browse -at" and just for this one "avahi-browse -rt _korra._tcp"
+    // On mac "dns-sd -B _services._dns-sd._tcp local" will list all services, "dns-sd -B _korra" will list just the ones for korra,
+    // and "dns-sd -L "Korra <mac>" _korra" will print the TXT for the particular device.
+#define SERVICE_NAME_FORMAT "Korra " FMT_LL_ADDR_6_LOWER_NO_COLONS "._korra"
+    size_t service_name_len = snprintf(NULL, 0, SERVICE_NAME_FORMAT, PRINT_LL_ADDR_6(props->mac_addr));
+    char service_name[service_name_len + 1] = {0};
+    snprintf(service_name, sizeof(service_name), SERVICE_NAME_FORMAT, PRINT_LL_ADDR_6(props->mac_addr));
+    mdns.addServiceRecord(service_name, 7007, MDNSServiceProtocol_t::MDNSServiceTCP, "\x05id=01");
+
+    setup = true;
+    Serial.println("Setting up mDNS is complete");
   }
 
-  // We register a service to aid with checking if the device is on the network. This aids troubleshooting
-  // service discovery where network has different conditions like mDNS/Bonjour disabled, different VLAN.
-  // The name must start with the description as per examples.
-  // Without the TXT record, sometimes execution crashes; see https://github.com/arduino-libraries/ArduinoMDNS/issues/36
-  //                                                          https://github.com/arduino-libraries/ArduinoMDNS/pull/23
-  // The TXT record "\x05id=01" implies TXT record with 5 bytes 'id=01' which is just a random key value pair
-  // Post 7007 is random, not using 80 to avoid confusion with HTTP.
-  // The service name includes the mac address to make it easier to identify multiple devices.
-  // You can list this on Linux using "avahi-browse -at" and just for this one "avahi-browse -rt _korra._tcp"
-  // On mac "dns-sd -B _services._dns-sd._tcp local" will list all services, "dns-sd -B _korra" will list just the ones for korra,
-  // and "dns-sd -L "Korra <mac>" _korra" will print the TXT for the particular device.
-#define SERVICE_NAME_FORMAT "Korra " FMT_LL_ADDR_6_LOWER_NO_COLONS "._korra"
-  size_t service_name_len = snprintf(NULL, 0, SERVICE_NAME_FORMAT, PRINT_LL_ADDR_6(props->mac_addr));
-  char service_name[service_name_len + 1] = {0};
-  snprintf(service_name, sizeof(service_name), SERVICE_NAME_FORMAT, PRINT_LL_ADDR_6(props->mac_addr));
-  mdns.addServiceRecord(service_name, 7007, MDNSServiceProtocol_t::MDNSServiceTCP, "\x05id=01");
-}
-
-void KorraMdns::maintain()
-{
   mdns.run();
 }
 

--- a/firmware-pio/src/mdns/korra_mdns.h
+++ b/firmware-pio/src/mdns/korra_mdns.h
@@ -30,20 +30,14 @@ public:
   ~KorraMdns();
 
   /**
-   * Initiate mDNS
-   *
-   * @param props Properties of the network interface.
-   */
-  void begin(const struct korra_network_props *props);
-
-  /**
    * This method should be called periodically inside the main loop of the firmware.
    * It's safe to call this method in some interval (like 5ms).
    */
-  void maintain();
+  void maintain(const struct korra_network_props *props);
 
 private:
   MDNS mdns;
+  bool setup = false;
 };
 
 #endif // BOARD_HAS_INTERNET

--- a/firmware-pio/src/sensors/korra_sensors.cpp
+++ b/firmware-pio/src/sensors/korra_sensors.cpp
@@ -9,8 +9,8 @@ void KorraSensors::begin()
 {
 #ifdef CONFIG_APP_KIND_KEEPER
   // TODO: confirm model or switch to auto detect
-  dht.setup(CONFIG_SENSORS_DHT21_PIN, DHTesp::AUTO_DETECT);
   dht.setup(CONFIG_SENSORS_DHT21_PIN, DHTesp::DHT11);
+  // dht.setup(CONFIG_SENSORS_DHT21_PIN, DHTesp::AUTO_DETECT);
 #endif // CONFIG_APP_KIND_KEEPER
 }
 

--- a/firmware-pio/src/time/korra_time.cpp
+++ b/firmware-pio/src/time/korra_time.cpp
@@ -14,7 +14,7 @@ void KorraTime::begin(uint32_t update_interval_sec)
     client.setUpdateInterval(update_interval_sec * 1000);
 }
 
-void KorraTime::sync()
+void KorraTime::maintain()
 {
     if (client.update())
     {
@@ -32,9 +32,4 @@ void KorraTime::sync()
         strftime(time_str, sizeof(time_str), "%FT%T", &tm);
         Serial.printf("Time is now %s\n", time_str);
     }
-}
-
-void KorraTime::maintain()
-{
-    sync();
 }

--- a/firmware-pio/src/time/korra_time.h
+++ b/firmware-pio/src/time/korra_time.h
@@ -37,12 +37,6 @@ public:
   void begin(uint32_t update_interval_sec = 60);
 
   /**
-   * Sync time once.
-   * Call this if you need to ensure sync early such as in main.
-   */
-  void sync();
-
-  /**
    * This method should be called periodically inside the main loop of the firmware.
    * It's safe to call this method in some interval (like 5ms).
    */


### PR DESCRIPTION
This avoids blocking processing of the shell commands. It also reduces the need to reboot when the network takes longer to connect because ESP keeps trying at the back. Auto reconnect is enabled which means we no longer need to seek connect more than once.