### PR TITLE
Added device twin logic to house firmware version and update info

### DIFF
--- a/.changeset/thin-taxis-behave.md
+++ b/.changeset/thin-taxis-behave.md
@@ -1,0 +1,5 @@
+---
+"firmware-pio": minor
+---
+
+Added device twin logic to house firmware version and update info

--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -85,6 +85,26 @@ resource iotDps 'Microsoft.Devices/provisioningServices@2022-12-12' = {
   sku: { name: 'S1', capacity: 1 }
 }
 
+resource iotUpdateAccount 'Microsoft.DeviceUpdate/accounts@2023-07-01' = {
+  name: name
+  location: location
+  properties: {
+    sku: 'Free'
+  }
+
+  /* Cannot create the instance with a free tier iot hub. Till then we do the magic manually */
+  // resource instance 'instances' = {
+  //   name: name
+  //   location: location
+  //   properties: {
+  //     enableDiagnostics: false
+  //     iotHubs: [{ resourceId: iotHub.id }]
+  //   }
+  // }
+
+  identity: { type: 'UserAssigned', userAssignedIdentities: { '${managedIdentity.id}': {} } }
+}
+
 /* Static WebApp */
 resource staticWebApp 'Microsoft.Web/staticSites@2024-11-01' = {
   name: name
@@ -113,6 +133,7 @@ resource staticWebApp 'Microsoft.Web/staticSites@2024-11-01' = {
 var roles = [
   { name: 'IoT Hub Data Contributor', id: '4fc6c259-987e-4a07-842e-c321cc9d413f' } // Allows for full access to IoT Hub data plane operations.
   { name: 'Device Provisioning Service Data Contributor', id: 'dfce44e4-17b7-4bd1-a6d1-04996ec95633' } // Allows for full access to Device Provisioning Service data-plane operations.
+  { name: 'Device Update Administrator', id: '02ca0879-e8e4-47a5-a61e-5c618b76e64a' } // Gives you full access to management and content operations
 ]
 
 resource roleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [

--- a/firmware-pio/scripts/version.py
+++ b/firmware-pio/scripts/version.py
@@ -19,23 +19,41 @@ def get_git_short_sha():
   except subprocess.CalledProcessError:
     return "000000000000"
 
-def get_version():
-  base_version = read_version_file()
-  version = f"{base_version}"
-
-  return version
+def parse_version(version):
+  parts = version.split("+")
+  base = parts[0]
+  tweak = parts[1] if len(parts) > 1 else "0"
+  major, minor, patch = (base.split(".") + ["0", "0"])[:3]
+  return int(major), int(minor), int(patch), tweak
 
 def write_version_header(version, output_path="firmware-pio/include/app_version.h"):
   os.makedirs(os.path.dirname(output_path), exist_ok=True)
+  major, minor, patch, tweak = parse_version(version)
+  version_number = (major << 16) | (minor << 8) | patch
+  app_version = (major << 16) | (minor << 8)
+  extended_str = f"{major}.{minor}.{patch}+{tweak}"
+  tweak_str = extended_str
   sha = get_git_short_sha()
+
   with open(output_path, "w") as f:
     f.write("// Auto-generated file, do not edit\n\n")
-    f.write("#ifndef VERSION_H // VERSION_H\n\n")
-    f.write(f'#define APP_VERSION_STRING "{version}"\n')
-    f.write(f'\n')
-    f.write(f'#define APP_BUILD_VERSION "{sha}"\n')
-    f.write("\n#endif // VERSION_H\n")
+    f.write("#ifndef _APP_VERSION_H_\n")
+    f.write("#define _APP_VERSION_H_\n\n")
 
-version = get_version()
+    f.write(f"#define APPVERSION                   0x{app_version:05x}\n")
+    f.write(f"#define APP_VERSION_NUMBER           0x{version_number:05x}\n")
+    f.write(f"#define APP_VERSION_MAJOR            {major}\n")
+    f.write(f"#define APP_VERSION_MINOR            {minor}\n")
+    f.write(f"#define APP_PATCHLEVEL               {patch}\n")
+    f.write(f"#define APP_TWEAK                    {tweak}\n")
+    f.write(f'#define APP_VERSION_STRING           "{major}.{minor}.{patch}"\n')
+    f.write(f'#define APP_VERSION_EXTENDED_STRING  "{extended_str}"\n')
+    f.write(f'#define APP_VERSION_TWEAK_STRING     "{tweak_str}"\n\n')
+
+    f.write(f'#define APP_BUILD_VERSION {sha}\n\n')
+
+    f.write("#endif // _APP_VERSION_H_\n")
+
+version = read_version_file()
 write_version_header(version)
 print(f"Generated firmware-pio/include/app_version.h")

--- a/firmware-pio/src/cloud/korra_cloud_provisioning.cpp
+++ b/firmware-pio/src/cloud/korra_cloud_provisioning.cpp
@@ -114,6 +114,7 @@ void KorraCloudProvisioning::maintain()
         mqtt.beginMessage(topic, /* retain */ false, /* qos */ 0, /* dup */ false);
         mqtt.print("{}"); // must be an empty json otherwise it won't work
         mqtt.endMessage();
+        request_id++;
         registration_requested = true;
     }
 }
@@ -201,7 +202,7 @@ void KorraCloudProvisioning::on_mqtt_message(int size)
     Serial.printf("Received a message on topic '%s', length %d bytes:\n", topic, size);
 
     // read payload
-    char payload[size + 1];
+    char payload[size + 1] = {0};
     mqtt.readBytes(payload, size);
     Serial.printf("%s\n", payload);
 

--- a/firmware-pio/src/cloud/korra_cloud_provisioning.h
+++ b/firmware-pio/src/cloud/korra_cloud_provisioning.h
@@ -186,8 +186,8 @@ private:
   registration_operation_status status;
   char *username = NULL;
   size_t username_len = 0;
+  uint16_t request_id = 1;
   bool registration_requested = false;
-  int request_id = 1;
   Timer<> &timer;
 
   /// Living instance of the KorraCloudProvisioning class. It can be nullptr.

--- a/firmware-pio/src/korra_config.h
+++ b/firmware-pio/src/korra_config.h
@@ -1,6 +1,8 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#define STRINGIFY(a) __STRINGIFY(a)
+
 #ifdef ARDUINO_ARCH_ESP32
 #define CONFIG_BOARD_HAS_WIFI 1
 #endif


### PR DESCRIPTION
Firmware updates are a requirement for the project. The easiest way to do this is via device twin properties in Azure IoT Hub where we set the current one in reported properties and receive updates via desired props. This PR adds logic for working with the device twin in this aspect. It is very specific to the use case of this project both in simplicity and structure. To make this logic more appropriate the versioning logic in `version.py` has been updated to match that for zephyr. This means we have both a string version (semver) and an integer version (shall be used to check if newer).

Actual firmware updates logic will follow.