### PR TITLE
Add actuator functionality which syncs with device twin

### DIFF
--- a/.changeset/tough-hornets-invent.md
+++ b/.changeset/tough-hornets-invent.md
@@ -1,0 +1,5 @@
+---
+"firmware-pio": minor
+---
+
+Add actuator functionality which syncs with device twin

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,11 @@ binaries
 
 node_modules/
 
-.DS_Store
-
 # PlatformIO
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .pio
 app_version.h
+
+.idea
+.DS_Store

--- a/firmware-pio/src/actuator/korra_actuator.cpp
+++ b/firmware-pio/src/actuator/korra_actuator.cpp
@@ -1,0 +1,115 @@
+#include "korra_actuator.h"
+
+// good default values for the actuator instead of having them as build flags
+static const struct korra_actuator_config default_config = {
+    .enabled = false,
+    .duration = 5,
+
+#ifdef CONFIG_APP_KIND_KEEPER
+    .target = 34.0f,
+#endif // CONFIG_APP_KIND_KEEPER
+
+#ifdef CONFIG_APP_KIND_POT
+    .target = 50.0f,
+#endif // CONFIG_APP_KIND_POT
+
+    .equilibrium_time = 3,
+};
+
+KorraActuator::KorraActuator() {
+  memcpy(&this->current_config, &default_config, sizeof(struct korra_actuator_config));
+}
+
+KorraActuator::~KorraActuator() {
+#ifdef CONFIG_APP_KIND_KEEPER
+  fan.detach();
+#endif // CONFIG_APP_KIND_KEEPER
+
+#ifdef CONFIG_APP_KIND_POT
+  pump.detach();
+#endif // CONFIG_APP_KIND_POT
+
+  state_updated_callback = nullptr;
+}
+
+void KorraActuator::begin() {
+#ifdef CONFIG_APP_KIND_KEEPER
+  fan.attach(CONFIG_ACTUATORS_FAN_PIN);
+#endif // CONFIG_APP_KIND_KEEPER
+
+#ifdef CONFIG_APP_KIND_POT
+  pump.attach(CONFIG_ACTUATORS_PUMP_PIN);
+#endif // CONFIG_APP_KIND_POT
+
+  timepoint = millis();
+}
+
+void KorraActuator::update(const struct korra_sensors_data *value) {
+#ifdef CONFIG_APP_KIND_KEEPER
+  current_value = value->temperature;
+#endif // CONFIG_APP_KIND_KEEPER
+
+#ifdef CONFIG_APP_KIND_POT
+  current_value = value->moisture;
+#endif // CONFIG_APP_KIND_POT
+
+  current_value_consumed = false;
+}
+
+void KorraActuator::maintain() {
+  // if actuator is disabled return
+  if (!current_config.enabled) return;
+
+  // if we have not consumed current values, the current value is less than the target value,
+  // and the time since the last actuation is greater than the equilibrium time then actuate
+
+  // check if the current value is less than the target value
+  if (!current_value_consumed && current_value < current_config.target) {
+    // check if the time since the last actuation is greater than the equilibrium time
+    const auto elapsed_time = (millis() - timepoint) / 1000;
+    if (elapsed_time > current_config.equilibrium_time) {
+      actuate();
+      timepoint = millis(); // reset the timepoint (must be done after actuation)
+      current_value_consumed = true;
+    }
+  }
+}
+
+void KorraActuator::set_config(const struct korra_actuator_config *value) {
+  // copy the config, logic will update in the maintain() function
+  memcpy(&current_config, value, sizeof(struct korra_actuator_config));
+}
+
+void KorraActuator::actuate() {
+  // Actuating for a given duration
+  // 0 is full speed forward
+  // 90 is stopped
+  // 180 is full speed reverse
+  const uint32_t duration = current_config.duration * 1000;
+  Serial.printf("Actuating for %d ms\n", duration);
+
+#ifdef CONFIG_APP_KIND_KEEPER
+
+  fan.write(0); // full speed forward
+  delay(duration);
+  fan.write(90); // stop
+
+#endif // CONFIG_APP_KIND_KEEPER
+
+#ifdef CONFIG_APP_KIND_POT
+
+  pump.write(0); // full speed forward
+  delay(duration);
+  pump.write(90); // stop
+
+#endif // CONFIG_APP_KIND_POT
+
+  // update the state
+  current_state.count++;
+  current_state.last_time = time(NULL);
+  current_state.total_duration += duration;
+  if (state_updated_callback) {
+    state_updated_callback(&current_state);
+  }
+  Serial.println(F("Actuation completed"));
+}

--- a/firmware-pio/src/actuator/korra_actuator.h
+++ b/firmware-pio/src/actuator/korra_actuator.h
@@ -1,0 +1,92 @@
+#ifndef KORRA_ACTUATOR_H
+#define KORRA_ACTUATOR_H
+
+#include "korra_config.h"
+#include "sensors/korra_sensors.h"
+
+#include <ESP32Servo.h>
+// #include <Servo.h>
+
+struct korra_actuator_config {
+  /** Whether or not the actuator is allowed */
+  bool enabled;
+
+  /**
+   * Seconds for which the actuator should be active at a given time (range: 5-60)
+   */
+  uint16_t duration;
+
+  /**
+   * The target value.
+   * @note This depends on the application.
+   * @note For pot, it is moisture (percentage).
+   * @note For keeper, it is temperature (Celsius).
+   */
+  float target;
+
+  /** Seconds to wait before the next actuation (range: 5-60) */
+  uint16_t equilibrium_time; //
+};
+
+struct korra_actuator_state {
+  /** Number of times the actuator was activated */
+  uint16_t count;
+
+  /** Last time the actuator was activated */
+  time_t last_time;
+
+  /** Total time the actuator was active */
+  uint32_t total_duration;
+};
+
+class KorraActuator {
+public:
+  KorraActuator();
+  ~KorraActuator();
+
+  void begin();
+  void maintain();
+  void update(const struct korra_sensors_data *value);
+  void set_config(const struct korra_actuator_config *value);
+
+  /**
+   * Registers callback that will be called each time the actuator state is updated.
+   *
+   * @param callback
+   */
+  inline void onStateUpdated(void (*callback)(const struct korra_actuator_state *value)) {
+    state_updated_callback = callback;
+  }
+
+  /**
+   * Returns the current state of the actuator.
+   */
+  inline const struct korra_actuator_state *state() { return &current_state; }
+
+  /**
+   * Returns the current configuration of the actuator.
+   */
+  inline const struct korra_actuator_config *config() { return &current_config; }
+
+private:
+  korra_actuator_config current_config = {0};
+  korra_actuator_state current_state = {0};
+  void (*state_updated_callback)(const struct korra_actuator_state *value) = NULL;
+
+  unsigned long timepoint = 0;
+  bool current_value_consumed = false;
+  float current_value = 0;
+
+#ifdef CONFIG_APP_KIND_KEEPER
+  Servo fan;
+#endif // CONFIG_APP_KIND_KEEPER
+
+#ifdef CONFIG_APP_KIND_POT
+  Servo pump;
+#endif // CONFIG_APP_KIND_POT
+
+private:
+  void actuate();
+};
+
+#endif // KORRA_ACTUATOR_H

--- a/firmware-pio/src/cloud/korra_cloud_hub.cpp
+++ b/firmware-pio/src/cloud/korra_cloud_hub.cpp
@@ -152,6 +152,9 @@ void KorraCloudHub::update(struct korra_device_twin_reported *props) {
   // A member set to null deletes the member from the containing object.
   doc["firmware"]["version"]["value"] = props->firmware.version.value;
   doc["firmware"]["version"]["semver"] = props->firmware.version.semver;
+  doc["actuator"]["count"] = props->actuator.count;
+  doc["actuator"]["last_time"] = props->actuator.last_time;
+  doc["actuator"]["total_duration"] = props->actuator.total_duration;
 
   // prepare topic
   size_t topic_len = snprintf(NULL, 0, TOPIC_FORMAT_TWIN_PATCH_REPORTED, request_id);
@@ -275,6 +278,10 @@ void KorraCloudHub::on_mqtt_message(int size) {
       size_t signature_raw_len = min((int)strlen(signature_raw) + 1, (int)sizeof(twin.desired.firmware.signature));
       memcpy(twin.desired.firmware.signature, signature_raw, signature_raw_len - 1);
     }
+    // desired.actuator.enabled
+    twin.desired.actuator.enabled = doc["desired"]["actuator"]["enabled"];
+    // desired.actuator.target
+    twin.desired.actuator.target = doc["desired"]["actuator"]["target"];
 
     // update the twin stored locally (reported)
     twin.reported.version = reported_version;

--- a/firmware-pio/src/cloud/korra_cloud_hub.h
+++ b/firmware-pio/src/cloud/korra_cloud_hub.h
@@ -11,30 +11,56 @@
 #include "internet/korra_network_shared.h"
 #include "korra_cloud_shared.h"
 
-struct korra_firmware_version {
+struct korra_device_twin_firmware_version {
   uint32_t value;
   char semver[20 + 1]; // human-readable version
 };
 
-struct korra_firmware_desired {
-  struct korra_firmware_version version; // version
-  char url[256 + 1];                     // firmware binary URL
-  char hash[64 + 1];                     // SHA-256 hash in hex
-  char signature[128 + 1];               // Signature (e.g., base64 or hex)
+struct korra_device_twin_desired_firmware {
+  struct korra_device_twin_firmware_version version; // version
+  char url[256 + 1];                                 // firmware binary URL
+  char hash[64 + 1];                                 // SHA-256 hash in hex
+  char signature[128 + 1];                           // Signature (e.g., base64 or hex)
 };
 
-struct korra_firmware_reported {
-  struct korra_firmware_version version; // version
+struct korra_device_twin_desired_actuator {
+  /** Whether the actuator is enabled. */
+  bool enabled;
+
+  /**
+   * The target value.
+   * @note This depends on the application.
+   * @note For pot, it is moisture (percentage).
+   * @note For keeper, it is temperature (Celsius).
+   */
+  float target;
 };
 
 struct korra_device_twin_desired {
   uint32_t version; // $version
-  struct korra_firmware_desired firmware;
+  struct korra_device_twin_desired_firmware firmware;
+  struct korra_device_twin_desired_actuator actuator;
+};
+
+struct korra_device_twin_reported_firmware {
+  struct korra_device_twin_firmware_version version; // version
+};
+
+struct korra_device_twin_reported_actuator {
+  /** Number of times the actuator was activated */
+  uint16_t count;
+
+  /** Last time the actuator was activated */
+  time_t last_time;
+
+  /** Total time the actuator was active */
+  uint32_t total_duration;
 };
 
 struct korra_device_twin_reported {
   uint32_t version; // $version
-  struct korra_firmware_reported firmware;
+  struct korra_device_twin_reported_firmware firmware;
+  struct korra_device_twin_reported_actuator actuator;
 };
 
 struct korra_device_twin {

--- a/firmware-pio/src/sensors/korra_sensors.cpp
+++ b/firmware-pio/src/sensors/korra_sensors.cpp
@@ -10,9 +10,7 @@ KorraSensors::~KorraSensors() {
 
 void KorraSensors::begin() {
 #ifdef CONFIG_APP_KIND_KEEPER
-  // TODO: confirm model or switch to auto detect
   dht.setup(CONFIG_SENSORS_DHT21_PIN, DHTesp::DHT11);
-  // dht.setup(CONFIG_SENSORS_DHT21_PIN, DHTesp::AUTO_DETECT);
 #endif // CONFIG_APP_KIND_KEEPER
 }
 

--- a/firmware-pio/src/sensors/korra_sensors.h
+++ b/firmware-pio/src/sensors/korra_sensors.h
@@ -15,15 +15,15 @@
 
 struct korra_sensors_data {
 #ifdef CONFIG_APP_KIND_KEEPER
-  // measured in °C
+  /** Measured in °C */
   float temperature;
 
-  // relative humidity (%)
+  /** Relative humidity (%) */
   float humidity;
 #endif // CONFIG_APP_KIND_KEEPER
 
 #ifdef CONFIG_APP_KIND_POT
-  // percentage (%) of water in a substance
+  /** Percentage (%) of water in a substance */
   int32_t moisture;
 
   float ph;

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,11 +27,13 @@ build_flags_keeper =
 	-D CONFIG_APP_NAME=\"keeper\"
 	-D CONFIG_APP_KIND_KEEPER=1
 	-D CONFIG_SENSORS_DHT21_PIN=10
+	-D CONFIG_ACTUATORS_FAN_PIN=11
 build_flags_pot = 
 	-D CONFIG_APP_NAME=\"pot\"
 	-D CONFIG_APP_KIND_POT=1
 	-D CONFIG_SENSORS_MOISTURE_PIN=15
 	-D CONFIG_SENSORS_PH_PIN=20
+	-D CONFIG_ACTUATORS_PUMP_PIN=11
 
 [env]
 lib_deps = 
@@ -42,6 +44,7 @@ lib_deps =
 	https://github.com/arduino-libraries/ArduinoMqttClient.git#0a07062
 	https://github.com/contrem/arduino-timer.git#2adf6b1
 	bblanchon/ArduinoJson@7.4.1
+	madhephaestus/ESP32Servo@3.0.6
 build_flags = 
 	-D CONFIG_INITIAL_BOOT_DELAY_SECONDS=3
 	-D CONFIG_SENSORS_READ_PERIOD_SECONDS=300


### PR DESCRIPTION
Implement actuator class with configuration and state management that works with the cloud hub for device twin synchronisation. The actuator config comes from the device twin's desired properties while the actuator state is pushed to the device twin's reported properties.

On reboot all the state is lost so the reported properties are reset back to zero. While this can be changed to store in `Preferences`/`NVM`, there is no real need to do so at this time.