### PR TITLE
Restore sensor read interval back to 5 min

### DIFF
--- a/firmware/Kconfig
+++ b/firmware/Kconfig
@@ -27,7 +27,7 @@ config AZURE_IOT_DPS_ID_SCOPE
 
 config SENSORS_READ_PERIOD_SECONDS
     int "Interval for collecting sensor data in seconds"
-    default 60
+    default 300
 
 config SNTP_SERVER_ADDRESS
     string "SNTP server address"

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ lib_deps =
 	https://github.com/contrem/arduino-timer.git#2adf6b1
 	bblanchon/ArduinoJson@7.4.2
 build_flags = 
-	-D CONFIG_SENSORS_READ_PERIOD_SECONDS=60
+	-D CONFIG_SENSORS_READ_PERIOD_SECONDS=300
 	-D CONFIG_DEVICE_CERTIFICATE_VALIDITY_YEARS=3
 	-D CONFIG_SNTP_SERVER_ADDRESS=\"uk.pool.ntp.org\"
 	-D CONFIG_AZURE_IOT_DPS_ID_SCOPE=\"0ne00F7ADA0\"


### PR DESCRIPTION
Using the free tier of the IoT Hub gives 8k messages/day. With 10-11 devices, I cannot do 1440 messages/device/day and still do twin events. Since an update can always be pushed when the hub tier is upgraded, we can reduce the frequency for now.

This reverts 4347a1f0e812d9ca8d05d766d038dfab1d40cc87