### PR TITLE
Update pio for ESP32 from 54.03.21 to 55.03.30

### DIFF
--- a/.changeset/dull-taxis-search.md
+++ b/.changeset/dull-taxis-search.md
@@ -2,4 +2,4 @@
 'firmware-pio': minor
 ---
 
-Update platform version for ESP32 environment from 54.02.21 to 55.03.30
+Update platform version for ESP32 environment from 54.03.21 to 55.03.30

--- a/.changeset/dull-taxis-search.md
+++ b/.changeset/dull-taxis-search.md
@@ -1,0 +1,5 @@
+---
+'firmware-pio': minor
+---
+
+Update platform version for ESP32 environment from 54.02.21 to 55.03.30

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ build_flags =
 	; -D MQTT_CLIENT_DEBUG=1
 
 [env:arduino-esp32]
-platform = https://github.com/pioarduino/platform-espressif32.git#54.03.21
+platform = https://github.com/pioarduino/platform-espressif32.git#55.03.30
 framework = arduino
 build_flags = 
 	; For boards with two ports, these allow use of the USB/JTAG port which has less noise


### PR DESCRIPTION
Release notes: https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.30

Summary:
- Updates Arduino Core for ESP32 from 3.2.1 to 3.3.0 
  https://github.com/espressif/arduino-esp32/releases/tag/3.3.0
- Updated ESP-IDF from 5.4.0 to 5.5.0
  https://github.com/espressif/esp-idf/releases/tag/v5.5